### PR TITLE
Make druid a separate indexed column on events

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -14,10 +14,10 @@ class MetricsController < ApplicationController
   private
 
   def views
-    Ahoy::Event.where_event('$view', druid: params[:druid])
+    Ahoy::Event.where(name: '$view', druid: params[:druid])
   end
 
   def downloads
-    Ahoy::Event.where_event('download', druid: params[:druid])
+    Ahoy::Event.where(name: 'download', druid: params[:druid])
   end
 end

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -10,5 +10,7 @@ module Ahoy
     belongs_to :visit
 
     serialize :properties, coder: JSON
+
+    before_save { self.druid = properties['druid'] }
   end
 end

--- a/db/migrate/20240214215212_extract_druid_from_event_properties.rb
+++ b/db/migrate/20240214215212_extract_druid_from_event_properties.rb
@@ -1,0 +1,19 @@
+class ExtractDruidFromEventProperties < ActiveRecord::Migration[7.1]
+  def change
+    # Add a druid column to the events table with index
+    add_column :ahoy_events, :druid, :string
+    add_index :ahoy_events, :druid
+
+    # Populate the new column using existing data in properties text field
+    reversible do |direction|
+      direction.up do
+        Ahoy::Event.find_each do |event|
+          event.update!(druid: event.properties['druid'])
+        end
+      end
+      direction.down do
+        # no-op
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_01_181445) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_14_215212) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.string "name"
     t.text "properties"
     t.datetime "time"
+    t.string "druid"
+    t.index ["druid"], name: "index_ahoy_events_on_druid"
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
     t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{Rails.root.join('spec/fixtures')}"
+  config.fixture_paths = ["#{Rails.root.join('spec/fixtures')}"]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
This creates a migration and adds a handler to set up a top-level
field on Event objects for the druid, so that it can be set and
queried without resorting to pulling it out of the properties
text field.

The changes is intended to address performance concerns for
objects with lots of non-unique events, where we need to do
queries by druid and then unique them by event id.
