### PR TITLE
Add a download/view report

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ The response is a single JSON object with total counts for each tracked event ty
 
 Counts labeled "unique" are deduplicated by visit, so that multiple events coming from the same device in a short time period are only counted once. This time period is configurable when initializing `ahoy.js`.
 
+### Reports
+
+If you would like to generate a CSV that reports views and downloads by DRUID you can:
+
+```shell
+bin/rake "report:downloads_and_views
+```
+
+That will generate a report from 2024-01-01 to the present. If you want to get the stats from 2024-06-01 to present you can:
+
+```shell
+bin/rake "report:downloads_and_views[2024-06-01]"
+```
+
+And similarly if you just want the month of June 2024 you can:
+
+```shell
+bin/rake "report:downloads_and_views[2024-06-01,2024-06-30]"
+```
+
 ## Testing
 
 Code is linted with [Rubocop](https://rubocop.org/) and tested with [RSpec](https://rspec.info/) on each push to GitHub. You can run everything locally with:

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/BlockLength
+namespace :report do
+  desc 'Generate a download/view report'
+  task :downloads_and_views, %i[start end] => :environment do |_, args|
+    args.with_defaults(start: '2024-01-01', end: DateTime.now.strftime)
+
+    # get view and download counts by druid, but only count them once per visit
+    # e.g. if a user visits a druid five times in what ahoy considers a unique visit
+    # it will only be counted once. this matches the counts you see in purl.
+
+    sql = <<~SQL.squish
+      SELECT druid, name, COUNT(*) AS count
+      FROM (
+        SELECT druid, visit_id, name
+        FROM ahoy_events
+        WHERE time >= $1
+        AND time <= $2
+        GROUP BY druid, visit_id, name
+      ) AS events
+      GROUP BY druid, name
+      ORDER BY druid
+    SQL
+
+    puts 'druid,view,download'
+
+    last_druid = nil
+    stats = { view: 0, download: 0 }
+
+    ActiveRecord::Base.connection.exec_query(sql, 'downloads_and_views', [args.start, args.end]).each do |row|
+      # accumulate view and download stats by druid on a single row
+      if last_druid && row['druid'] != last_druid
+        puts "#{last_druid},#{stats['view']},#{stats['download']}"
+        stats = { view: 0, download: 0 }
+        last_druid = row['druid']
+      end
+
+      last_druid = row['druid']
+      event_type = row['name'] == '$view' ? 'view' : 'download'
+      stats[event_type] = row['count']
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
This commit adds a report of downloads and views by DRUID, which you can run like:

```
bin/rake report:downloads_and_views
```

Which will generate a CSV of download/view statistics by druid from 2024-01-01 to the present. 2024-01-01 is when our stats gathering began.

If you would prefer to get the totals since another date you can:

```
bin/rake "report:downloads_and_views[2024-05-01]"
```

or:

```
bin/rake "report:downloads_and_views[2024-06-01,2024-06-30]"
```
